### PR TITLE
Add support for msgpack and common base timeout exception class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,12 @@
+Changelog
+=========
+
+0.2.0 (2017-09-28)
+------------------
+- Make sure file uploads work correctly when the data is coming from Pyramid
+- Make sure query and form data values are strings
+- Don't use Python 3.6 f-string syntax (stay compatible to Python 3.5)
+
+0.1.0 (2017-07-28)
+------------------
+- Initial release

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,9 @@ Installation
 Project status
 --------------
 
-The project is very much work in progress. Expect bugs. If you find any, please file an issue!
+The project is still work in progress, although it is successfully used in production at Yelp. We have an integration
+test suite that not only covers bravado-asyncio behavior, but also makes sure that behavior is equal to the (default)
+synchronous bravado HTTP client. That said, if you find a bug please file an issue!
 
 Internal as well as external interfaces may change at any time currently. That said, since bravado expects
 the HTTP client to adhere to a specific interface, those parts should be relatively stable.

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -70,6 +70,11 @@ class AioHTTPResponseAdapter(IncomingResponse):
         return future.result(self._remaining_timeout)
 
     @property
+    def raw_bytes(self):
+        future = asyncio.run_coroutine_threadsafe(self._delegate.read(), get_loop())
+        return future.result(self._remaining_timeout)
+
+    @property
     def reason(self):
         return self._delegate.reason
 
@@ -156,6 +161,9 @@ class AsyncioClient(HttpClient):
 
 
 class AsyncioFutureAdapter(FutureAdapter):
+
+    timeout_errors = (concurrent.futures.TimeoutError,)
+
     def __init__(self, future: concurrent.futures.Future) -> None:
         self.future = future
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
+bravado-core>=4.11.0
+bravado>=9.2.0
 coverage
 ephemeral_port_reserve
 mock
 pytest
 tox
+u-msgpack-python

--- a/testing/integration_server.py
+++ b/testing/integration_server.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import os.path
 
+import umsgpack
 from aiohttp import web
 
 
@@ -40,6 +41,20 @@ async def get_pet(request):
         'name': 'Lili',
         'photoUrls': [],
     })
+
+
+async def search_pets(request):
+    pet_name = request.query['petName']
+    if pet_name == 'lili':
+        response = [{
+            'id': 42,
+            'name': 'Lili',
+            'photoUrls': [],
+        }]
+    else:
+        response = []
+
+    return web.Response(body=umsgpack.packb(response), content_type='application/msgpack')
 
 
 async def update_pet_formdata(request):
@@ -103,6 +118,7 @@ def setup_routes(app):
     app.router.add_get('/swagger.yaml', swagger_spec)
     app.router.add_get('/store/inventory', store_inventory)
     app.router.add_get('/user/login', login)
+    app.router.add_get('/pet/search', search_pets)
     app.router.add_get('/pet/{petId}', get_pet)
     app.router.add_post('/pet/{petId}', update_pet_formdata)
     app.router.add_post('/pet/{petId}/uploadImage', upload_pet_image)

--- a/testing/swagger.yaml
+++ b/testing/swagger.yaml
@@ -107,6 +107,28 @@ paths:
           description: "Successful operation"
         404:
           description: "Pet not found"
+  /pet/search:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by Name"
+      description: "Returns all pets matching the name"
+      operationId: "getPetsByName"
+      produces:
+      - "application/msgpack"
+      parameters:
+      - name: "petName"
+        in: "query"
+        description: "Name or part of the name of the pet"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
   /pet/{petId}/uploadImage:
     post:
       tags:


### PR DESCRIPTION
This CR also adds end-to-end tests for msgpack with bravado-asyncio and requests as well as for the timeout feature. I'll update the CHANGELOG once I make the new release (which will be 0.3.0).