### PR TITLE
Rework tox.ini so that we specify Python versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,47 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.7.1
+    sha: v1.1.1
     hooks:
     -   id: autopep8-wrapper
-        language_version: python3
+        language_version: python3.6
         args:
         - -i
         - --ignore=E309,E501
     -   id: check-added-large-files
-        language_version: python3
+        language_version: python3.6
     -   id: check-byte-order-marker
-        language_version: python3
+        language_version: python3.6
     -   id: check-json
-        language_version: python3
+        language_version: python3.6
     -   id: check-yaml
-        language_version: python3
+        language_version: python3.6
     -   id: debug-statements
-        language_version: python3
+        language_version: python3.6
     -   id: end-of-file-fixer
-        language_version: python3
+        language_version: python3.6
     -   id: fix-encoding-pragma
-        language_version: python3
+        language_version: python3.6
         args:
         - --remove
     -   id: flake8
-        language_version: python3
+        language_version: python3.6
     -   id: name-tests-test
-        language_version: python3
+        language_version: python3.6
     -   id: trailing-whitespace
-        language_version: python3
+        language_version: python3.6
     -   id: requirements-txt-fixer
-        language_version: python3
+        language_version: python3.6
         files: requirements-dev.txt
 -   repo: https://github.com/asottile/pyupgrade
-    sha: v1.0.0
+    sha: v1.2.0
     hooks:
     -   id: pyupgrade
-        language_version: python3
--   repo: git@git.yelpcorp.com:mirrors/asottile/reorder_python_imports
-    sha: v0.3.1
+        language_version: python3.6
+-   repo: https://github.com/asottile/reorder_python_imports
+    sha: v0.3.5
     hooks:
     -   id: reorder-python-imports
-        language_version: python3
+        language_version: python3.6
         args: [
             '--remove-import', 'from __future__ import absolute_import',
             '--remove-import', 'from __future__ import print_function',

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
   - env: TOXENV=py35
     python: "3.5"
-  - env: TOXENV=cover
+  - env: TOXENV=py36
     python: "3.6"
   - env: TOXENV=pre-commit
     python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     python: "3.5"
   - env: TOXENV=cover
     python: "3.6"
+  - env: TOXENV=pre-commit
+    python: "3.6"
 
 install:
 - "pip install tox coveralls"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test: devenv
 	venv/bin/tox
 
 venv:
-	virtualenv -p python3 venv
+	virtualenv -p python3.6 venv
 
 .PHONY: clean
 clean:

--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,10 @@ the HTTP client to adhere to a specific interface, those parts should be relativ
 Development and contributing
 ----------------------------
 
-Developing ``bravado-asyncio`` requires a working installation of Python 3.5 or 3.6 with the
+Developing ``bravado-asyncio`` requires a working installation of Python 3.6 with the
 `virtualenv <https://virtualenv.pypa.io/en/stable/>`_ package being installed.
-All other requirements will be installed in a virtualenv created in the ``venv`` directory.
+All other requirements will be installed in a virtualenv created in the ``venv`` directory. A full run of our testsuite
+runs the tests against Python 3.5 and 3.6, so if you want that to work you should install Python 3.5 as well.
 
 1. Run ``make``. This will create the virtualenv you will use for development, with all runtime and development
    dependencies installed.
@@ -80,15 +81,16 @@ All other requirements will be installed in a virtualenv created in the ``venv``
    environment, please do so. If you prefer not to use aactivator, do ``source .activate.sh``.
 3. Make sure everything is set up correctly by running ``make test``.
 
-Note that ``make test`` will run the tests with whatever version of Python 3 you have installed - i.e. whatever
-version ``python3`` points to. Adjust your shell path settings accordingly to use a different Python version.
-Alternatively, you can ask tox to run tests with a specific Python version like so:
+Since ``make test`` will run tests with Python 3.5 and 3.6, you'll get an error if only one of them is installed.
+You can ask tox to run tests with a specific Python version like so:
 
 .. code-block:: bash
 
-     $ tox -e py36
+     $ tox -e py35
 
-This will run tests with Python 3.6.
+This will run tests with Python 3.5.
+
+We do run linters that currently require Python 3.6. You can run them with ``tox -e pre-commit``.
 
 Travis (the continuous integration system) will run tests with both Python 3.5 and Python 3.6, so make sure you don't
 write code that works on Python 3.6 only.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = cover, pre-commit
+envlist = py35, py36, pre-commit
 
 [testenv]
-basepython = python3
 deps =
     -rrequirements-dev.txt
 commands =
@@ -14,7 +13,7 @@ exclude = .git,__pycache__,.tox,docs,venv
 max_line_length = 120
 
 [testenv:pre-commit]
-basepython = python3
+basepython = python3.6
 deps =
     pre-commit
 setenv =


### PR DESCRIPTION
The original idea behind the tox.ini design was to allow users to use any Python 3 version that's compatible with bravado-asyncio (e.g. Python 3.5, 3.6, in-development 3.7). Unfortunately we're running into problems executing tests internally on machines where the default Python 3 version is 3.4. So I'm reworking tox.ini to explicitly specify the Python versions we support. Developers will be required to have a working Python 3.6 installation.

I'm also updating pre-commit hooks, fixing an issue that prevented them from fully working outside of Yelp, and running them as part of our travis build.