### PR TITLE
2013 query params list

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -13,6 +13,7 @@ from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 from bravado_core.response import IncomingResponse
+from multidict import MultiDict
 
 log = logging.getLogger(__name__)
 
@@ -154,10 +155,13 @@ class AsyncioClient(HttpClient):
         if not params:
             return params
 
-        prepared_params = {
-            name: str(value) for name, value in params.items()
-        }
-        return prepared_params
+        items = []
+        for key, value in params.items():
+            if isinstance(value, list):
+                items.extend((key, str(item)) for item in value)
+            else:
+                items.append((key, str(value)))
+        return MultiDict(items)
 
 
 class AsyncioFutureAdapter(FutureAdapter):

--- a/testing/integration_server.py
+++ b/testing/integration_server.py
@@ -114,6 +114,25 @@ async def delete_pet(request):
     return web.json_response({})
 
 
+async def get_pets(request):
+    pet_ids = request.query.getall('petIds')
+    if pet_ids != ['23', '42']:
+        return web.HTTPNotFound()
+
+    pets = [
+        {
+            'id': 23,
+            'name': 'Takamoto',
+            'photoUrls': [],
+        }, {
+            'id': 42,
+            'name': 'Lili',
+            'photoUrls': [],
+        },
+    ]
+    return web.json_response(pets)
+
+
 def setup_routes(app):
     app.router.add_get('/swagger.yaml', swagger_spec)
     app.router.add_get('/store/inventory', store_inventory)
@@ -124,6 +143,7 @@ def setup_routes(app):
     app.router.add_post('/pet/{petId}/uploadImage', upload_pet_image)
     app.router.add_put('/pet', update_pet)
     app.router.add_delete('/pet', delete_pet)
+    app.router.add_get('/pets', get_pets)
 
 
 if __name__ == '__main__':

--- a/testing/swagger.yaml
+++ b/testing/swagger.yaml
@@ -167,6 +167,36 @@ paths:
           description: "successful operation"
         400:
           description: "data incorrect"
+  /pets:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pets by ID"
+      description: "Returns a list of pets"
+      operationId: "getPetsByIds"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "petIds"
+        in: "query"
+        description: "IDs of pets to return"
+        required: true
+        type: "array"
+        items:
+          type: "integer"
+          format: "int64"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
   /store/inventory:
     get:
       tags:

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -41,6 +41,30 @@ def test_get_query_args(swagger_client):
     assert response.headers['X-Expires-After'] == 'Expiration date'
 
 
+def test_param_multi(swagger_client):
+    result, response = swagger_client.pet.getPetsByIds(
+        petIds=[23, 42],
+    ).result(timeout=1)
+
+    assert len(result) == 2
+    assert result[0]._as_dict() == {
+        'id': 23,
+        'name': 'Takamoto',
+        'photoUrls': [],
+        'category': None,
+        'status': None,
+        'tags': None,
+    }
+    assert result[1]._as_dict() == {
+        'id': 42,
+        'name': 'Lili',
+        'photoUrls': [],
+        'category': None,
+        'status': None,
+        'tags': None,
+    }
+
+
 def test_response_headers(swagger_client):
     """Make sure response headers are returned in the same format across HTTP clients. Namely,
     make sure names and values are str, and that it's possible to access headers in a

--- a/tests/prepare_params_test.py
+++ b/tests/prepare_params_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from bravado_asyncio.http_client import AsyncioClient
+
+
+@pytest.mark.parametrize('params', [
+    {'key': ['list', 'of', 'values']},
+    {'key': ['value']},
+])
+def test_prepare_params(params):
+    client = AsyncioClient()
+    prepared = client.prepare_params(params)
+    assert prepared.getall('key') == params['key']


### PR DESCRIPTION
For GET params that are lists, bravado-asyncio does not encode the params like other http clients, e.g. requests, by repeatingly appending the key value pairs, but uses `str(value)`.
