### PR TITLE
Add handling of timeout setting in request_options

### DIFF
--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -155,10 +155,16 @@ def test_server_500(swagger_client):
         swagger_client.pet.deletePet(petId=42).result(timeout=1)
 
 
-def test_timeout(swagger_client):
+def test_timeout_on_future(swagger_client):
     with pytest.raises(BravadoTimeoutError):
         bravado_future = swagger_client.store.getInventory()
         bravado_future.result(timeout=0.1)
+
+
+def test_timeout_request_options(swagger_client):
+    with pytest.raises(BravadoTimeoutError):
+        bravado_future = swagger_client.store.getInventory(_request_options={'timeout': 0.1})
+        bravado_future.result(timeout=None)
 
 
 def test_client_from_asyncio(integration_server):


### PR DESCRIPTION
We have two ways of setting a timeout in bravado, and only one is currently supported by bravado-asyncio. Let's add support for the other.