### PR TITLE
Only set content type for POST/PUT requests

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -126,12 +126,17 @@ class AsyncioClient(HttpClient):
             )
         timeout = request_params.get('timeout')
 
+        # aiohttp always adds a Content-Type header, and this breaks some servers that don't
+        # expect it for non-POST/PUT requests: https://github.com/aio-libs/aiohttp/issues/457
+        skip_auto_headers = ['Content-Type'] if request_params.get('method') not in ['POST', 'PUT'] else None
+
         coroutine = self.client_session.request(
             method=request_params.get('method') or 'GET',
             url=request_params.get('url'),
             params=params,
             data=data,
             headers=request_params.get('headers'),
+            skip_auto_headers=skip_auto_headers,
             timeout=timeout,
         )
 

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -58,6 +58,7 @@ def test_request(asyncio_client, mock_client_session, request_params):
         params=None,
         data=mock.ANY,
         headers={},
+        skip_auto_headers=['Content-Type'],
         timeout=None,
     )
     assert mock_client_session.return_value.request.call_args[1]['data']._fields == []
@@ -87,6 +88,7 @@ def test_simple_get(asyncio_client, mock_client_session, request_params):
         params=request_params['params'],
         data=mock.ANY,
         headers={},
+        skip_auto_headers=['Content-Type'],
         timeout=None,
     )
     assert mock_client_session.return_value.request.call_args[1]['data']._fields == []
@@ -119,6 +121,7 @@ def test_formdata(asyncio_client, mock_client_session, request_params, param_nam
         params=None,
         data=mock.ANY,
         headers={},
+        skip_auto_headers=['Content-Type'],
         timeout=None,
     )
 


### PR DESCRIPTION
The `Content-Type` header being present on GET requests breaks some application servers; let's make sure we only send it when necessary.