### PR TITLE
Fix installation of bravado-asyncio on Python < 3.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
-        'aiohttp',
+        'aiohttp ;python_full_version>="3.5.3"',  # aiohttp 3.0 requires at least Python 3.5.3
+        'aiohttp<3.0 ;python_full_version<"3.5.3"',
         'bravado',
     ],
     extras_require={


### PR DESCRIPTION
aiohttp requires Python 3.5.3 since release 3.0, and will throw an error during installation if the Python version is lower. Let's use PEP 508 environment markers to deal with this.