### PR TITLE
Update conditional aiohttp dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 matrix:
   include:
   - env: TOXENV=py35
+    # Ensure one test with a python version that does not support aiohttp>=3
+    python: "3.5.2"
+  - env: TOXENV=py35
     python: "3.5"
   - env: TOXENV=py36
     python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import sys
 
 from setuptools import setup
 
@@ -10,7 +9,6 @@ about = {}
 with open(os.path.join(base_dir, 'bravado_asyncio', '__init__.py')) as f:
     exec(f.read(), about)
 
-aiohttp_requirement = 'aiohttp' if sys.version_info >= (3, 5, 3) else 'aiohttp<3.0'
 
 setup(
     name='bravado-asyncio',
@@ -32,12 +30,13 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
-        aiohttp_requirement,
+        'aiohttp',
         'bravado',
     ],
     extras_require={
         # as recommended by aiohttp, see http://aiohttp.readthedocs.io/en/stable/#library-installation
         'aiohttp_extras': ['aiodns', 'cchardet'],
         'aiobravado': ['aiobravado'],
+        ':python_version<"3.5.3"': 'aiohttp<3',
     },
 )


### PR DESCRIPTION
The goal of this PR is to make setup.py more wheel friendly (context on #13).

In case of python<3.5.3 extra_requires will ensure that aiohttp is bounded to ``aiohttp<3.0``.
To guarantee that this approach will be effective for "old" python versions I've added a new travis task that uses python 3.5.2

NOTE: internally, this approach is already in use (ie. bravado_decorators)