### PR TITLE
Installation still fails on Python < 3.5.3 in certain cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,14 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
-        'aiohttp',
         'bravado',
     ],
     extras_require={
         # as recommended by aiohttp, see http://aiohttp.readthedocs.io/en/stable/#library-installation
         'aiohttp_extras': ['aiodns', 'cchardet'],
         'aiobravado': ['aiobravado'],
+        # Pick the right version of aiohttp
+        ':python_version>="3.5.3"': 'aiohttp',
         ':python_version<"3.5.3"': 'aiohttp<3',
     },
 )


### PR DESCRIPTION
Let's hopefully fix it once and for all. I've tested this manually and installation was still failing if done with pip.