### PR TITLE
Add connection error support and bravado integration tests

### DIFF
--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import time
 from typing import Optional
 
+import aiohttp.client_exceptions
 from bravado.http_future import FutureAdapter as BaseFutureAdapter
 
 from bravado_asyncio.definitions import AsyncioResponse
@@ -13,6 +14,7 @@ class FutureAdapter(BaseFutureAdapter):
     a normal Python function, and we expect future to be from the concurrent.futures module."""
 
     timeout_errors = (concurrent.futures.TimeoutError,)
+    connection_errors = (aiohttp.client_exceptions.ClientError,)
 
     def __init__(self, future: concurrent.futures.Future) -> None:
         self.future = future
@@ -31,6 +33,7 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
     a coroutine, and we expect future to be awaitable."""
 
     timeout_errors = (asyncio.TimeoutError,)
+    connection_errors = (aiohttp.client_exceptions.ClientError,)
 
     def __init__(self, future: asyncio.Future) -> None:
         self.future = future

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -142,7 +142,11 @@ class AsyncioClient(HttpClient):
             url=request_params.get('url'),
             params=params,
             data=data,
-            headers=request_params.get('headers'),
+            headers={
+                # Convert not string headers to string
+                k: str(v)
+                for k, v in request_params.get('headers', {}).items()
+            },
             skip_auto_headers=skip_auto_headers,
             timeout=timeout,
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 aiobravado
+bottle
 bravado-core>=4.11.0
-bravado>=9.2.0
+bravado[testing]>=10.1.0
 coverage
 ephemeral_port_reserve
 mock

--- a/tests/integration/bravado_integration_test.py
+++ b/tests/integration/bravado_integration_test.py
@@ -1,0 +1,17 @@
+import aiohttp.client_exceptions
+from bravado.testing.integration_test import IntegrationTestsBaseClass
+
+from bravado_asyncio.future_adapter import FutureAdapter
+from bravado_asyncio.http_client import AsyncioClient
+
+
+class TestServerBravadoAsyncioClient(IntegrationTestsBaseClass):
+
+    http_client_type = AsyncioClient
+    http_future_adapter_type = FutureAdapter
+    connection_errors_exceptions = {
+        aiohttp.client_exceptions.ClientError()
+    }
+
+    def cancel_http_future(self, http_future):
+        http_future.future.future.cancel()


### PR DESCRIPTION
The goal of this PR is to add support for ConnectionErrors (as exposed by bravado>=10.1.0) and to run the bravado offered integration tests.

While running the tests I also noticed that non-string headers defined in `_request_options` are not converted to strings (this operation is done for the requests and fido client), so I thought about to address that too.
