### PR TITLE
boolean query param values are lowercased in the newest bravado library

### DIFF
--- a/testing/integration_server.py
+++ b/testing/integration_server.py
@@ -22,7 +22,7 @@ async def login(request):
     if not (
         request.query.get('username') == 'asyncio'
         and request.query.get('password') == 'p%s&wörd?'
-        and request.query.get('invalidate_sessions') == 'True'
+        and request.query.get('invalidate_sessions') in ('True', 'true')
     ):
         return web.HTTPBadRequest()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ def integration_server():
     server_port = ephemeral_port_reserve.reserve()
     server = subprocess.Popen(
         ['python', script_name, '-p', str(server_port)],
-        stdin=None, stdout=subprocess.DEVNULL, stderr=None,
+        stdin=None, stdout=None, stderr=None,
     )
     wait_unit_service_starts('http://localhost:{port}'.format(port=server_port))
 


### PR DESCRIPTION
We need to account for that.

It also looks like that aiohttp doesn't print request logs to stdout anymore, so I'm removing the redirection to /dev/null.