### PR TITLE
aiohttp added type annotations which caused our build to fail

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -3,6 +3,7 @@ import logging
 from collections import Mapping
 from typing import Any
 from typing import Callable  # noqa: F401
+from typing import cast
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -140,7 +141,7 @@ class AsyncioClient(HttpClient):
 
         coroutine = self.client_session.request(
             method=request_params.get('method') or 'GET',
-            url=request_params.get('url'),
+            url=cast(str, request_params.get('url', '')),
             params=params,
             data=data,
             headers={

--- a/bravado_asyncio/response_adapter.py
+++ b/bravado_asyncio/response_adapter.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import TypeVar
 
@@ -40,7 +41,7 @@ class AioHTTPResponseAdapter(IncomingResponse):
 
     @property
     def reason(self) -> str:
-        return self._delegate.reason  # type: ignore  # aiohttp.ClientResponse doesn't annotate this attribute correctly
+        return cast(str, self._delegate.reason)  # aiohttp 3.4.0 doesn't annotate this attribute correctly
 
     @property
     def headers(self) -> CIMultiDict:

--- a/bravado_asyncio/response_adapter.py
+++ b/bravado_asyncio/response_adapter.py
@@ -40,7 +40,7 @@ class AioHTTPResponseAdapter(IncomingResponse):
 
     @property
     def reason(self) -> str:
-        return self._delegate.reason
+        return self._delegate.reason  # type: ignore  # aiohttp.ClientResponse doesn't annotate this attribute correctly
 
     @property
     def headers(self) -> CIMultiDict:

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,5 +5,6 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 
 [mypy-bravado_asyncio.*]
-disallow_untyped_calls = True
+# currently aiohttp has partial type annotations which cause errors if this option is set
+disallow_untyped_calls = False
 disallow_untyped_defs = True


### PR DESCRIPTION
The code is not fully type annotated, which means we need to change our mypy.ini configuration for now. I'm a bit surprised that mypy picks these annotations up, since I'm not seeing the PEP 561 `py.typed` marker.

Tests are only failing on Python 3.6 since we're using an earlier version of aiohttp on Python 3.5. aiohttp 3.4.0 introduced type annotations.

These are the errors I see if I don't allow untyped calls:

````
bravado_asyncio/http_client.py:49: error: Call to untyped function "ClientSession" in typed context
bravado_asyncio/http_client.py:50: error: Incompatible return value type (got "Optional[ClientSession]", expected "ClientSession")
bravado_asyncio/http_client.py:86: error: Call to untyped function "ClientSession" in typed context
bravado_asyncio/http_client.py:110: error: Call to untyped function "FormData" in typed context
bravado_asyncio/http_client.py:126: error: Call to untyped function "add_field" in typed context
````