### PR TITLE
Add optional loop parameter to future adapter

### DIFF
--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -38,9 +38,9 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
     def __init__(self, future: asyncio.Future) -> None:
         self.future = future
 
-    async def result(self, timeout: Optional[float] = None) -> AsyncioResponse:
+    async def result(self, timeout: Optional[float] = None, loop=None) -> AsyncioResponse:
         start = time.monotonic()
-        response = await asyncio.wait_for(self.future, timeout=timeout)
+        response = await asyncio.wait_for(self.future, timeout=timeout, loop=loop)
         time_elapsed = time.monotonic() - start
         remaining_timeout = timeout - time_elapsed if timeout else None
 

--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -38,7 +38,7 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
     def __init__(self, future: asyncio.Future) -> None:
         self.future = future
 
-    async def result(self, timeout: Optional[float] = None, loop=None) -> AsyncioResponse:
+    async def result(self, timeout: Optional[float] = None, loop: Optional[Type[asyncio.base_events.BaseEventLoop]]=None) -> AsyncioResponse:
         start = time.monotonic()
         response = await asyncio.wait_for(self.future, timeout=timeout, loop=loop)
         time_elapsed = time.monotonic() - start

--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -1,7 +1,10 @@
 import asyncio
 import concurrent.futures
 import time
-from typing import Optional
+from typing import (
+    Optional,
+    Type,
+    )
 
 import aiohttp.client_exceptions
 from bravado.http_future import FutureAdapter as BaseFutureAdapter

--- a/tests/future_adapter_test.py
+++ b/tests/future_adapter_test.py
@@ -53,7 +53,7 @@ def test_asyncio_future_adapter(mock_future, mock_wait_for, mock_response, event
     assert result.response is mock_response
     assert 0 < result.remaining_timeout < 5
 
-    mock_wait_for.assert_called_once_with(mock_future, timeout=5)
+    mock_wait_for.assert_called_once_with(mock_future, timeout=5, loop=None)
 
 
 def test_asyncio_future_adapter_timeout_error_class():


### PR DESCRIPTION
There are cases where forgetting to add  or provide loop parameters to asyncio APIs result in hard to debug issues. Added an optional loop parameter to the result API