### PR TITLE
Connect timeout support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 matrix:
   include:
   - env: TOXENV=py35
-    # Ensure one test with a python version that does not support aiohttp>=3
-    python: "3.5.2"
-  - env: TOXENV=py35
     python: "3.5"
   - env: TOXENV=py36
     python: "3.6"

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import ssl
 from collections import Mapping
-from distutils.version import LooseVersion
 from typing import Any
 from typing import Callable  # noqa: F401
 from typing import cast
@@ -158,9 +157,10 @@ class AsyncioClient(HttpClient):
 
         params = self.prepare_params(request_params.get('params'))
 
-        connect_timeout = request_params.get('connect_timeout')
-        request_timeout = request_params.get('timeout')
-        timeout = aiohttp.ClientTimeout(
+        connect_timeout = request_params.get('connect_timeout')  # type: Optional[float]
+        request_timeout = request_params.get('timeout')  # type: Optional[float]
+        # mypy thinks the type of total and connect is float, even though it is Optional[float]. Let's ignore the error.
+        timeout = aiohttp.ClientTimeout(  # type: ignore
             total=request_timeout,
             connect=connect_timeout,
         ) if (connect_timeout or request_timeout) else None
@@ -204,12 +204,6 @@ class AsyncioClient(HttpClient):
         return MultiDict(items)
 
     def _get_ssl_params(self) -> Dict[str, Any]:
-        aiohttp_version = LooseVersion(aiohttp.__version__)
-        if aiohttp_version < LooseVersion('3'):
-            if (self.ssl_verify is not None) or (self.ssl_context is not None):
-                log.warning('SSL options are not supported and will be ignored for aiohttp versions below 3.')
-            return {}
-        else:
-            return {
-                'ssl': self.ssl_context if self.ssl_context else self.ssl_verify
-            }
+        return {
+            'ssl': self.ssl_context if self.ssl_context else self.ssl_verify
+        }

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -159,12 +159,11 @@ class AsyncioClient(HttpClient):
         params = self.prepare_params(request_params.get('params'))
 
         connect_timeout = request_params.get('connect_timeout')
-        if connect_timeout:
-            log.warning(
-                'bravado-asyncio does not support setting a connect_timeout '
-                '(you passed a value of {})'.format(connect_timeout),
-            )
-        timeout = request_params.get('timeout')
+        request_timeout = request_params.get('timeout')
+        timeout = aiohttp.ClientTimeout(
+            total=request_timeout,
+            connect=connect_timeout,
+        ) if (connect_timeout or request_timeout) else None
 
         # aiohttp always adds a Content-Type header, and this breaks some servers that don't
         # expect it for non-POST/PUT requests: https://github.com/aio-libs/aiohttp/issues/457

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
+        'aiohttp>=3.3',
         'bravado>=10.0.0',
         'yelp-bytes',
     ],
@@ -37,8 +38,5 @@ setup(
         # as recommended by aiohttp, see http://aiohttp.readthedocs.io/en/stable/#library-installation
         'aiohttp_extras': ['aiodns', 'cchardet'],
         'aiobravado': ['aiobravado'],
-        # Pick the right version of aiohttp
-        ':python_version>="3.5.3"': 'aiohttp',
-        ':python_version<"3.5.3"': 'aiohttp<3',
     },
 )


### PR DESCRIPTION
This branch adds support for connect timeouts. For this we require aiohttp version 3.3 or later, which means that the minimum Python version is 3.5.3. Since this is an aiohttp requirement and not a bravado-asyncio requirement we're not going to add that to setup.py - instead the installation of aiohttp will fail if that requirement is not met.

Fixes #24.