### PR TITLE
Use tox-pip-extensions for creating the virtualenvs

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -160,7 +160,7 @@ class AsyncioClient(HttpClient):
         connect_timeout = request_params.get('connect_timeout')  # type: Optional[float]
         request_timeout = request_params.get('timeout')  # type: Optional[float]
         # mypy thinks the type of total and connect is float, even though it is Optional[float]. Let's ignore the error.
-        timeout = aiohttp.ClientTimeout(  # type: ignore
+        timeout = aiohttp.ClientTimeout(
             total=request_timeout,
             connect=connect_timeout,
         ) if (connect_timeout or request_timeout) else None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ mock
 mypy
 pytest
 tox
+tox-pip-extensions
 u-msgpack-python
 wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py35, py36, pre-commit
+tox_pip_extensions_ext_venv_update = true
+tox_pip_extensions_ext_pip_custom_platform = true
 
 [testenv]
 deps =


### PR DESCRIPTION
This should help with a wheel installation issue we see internally. Also I'm trying to fix the build, I'm not sure why all of a sudden it thinks the `type: ignore` comment is not needed anymore - or why it was required originally. 