### PR TITLE
Implement future.cancel(), fix type annotations

### DIFF
--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -1,12 +1,19 @@
 import asyncio
 import concurrent.futures
 import time
+from typing import Any
 from typing import Optional
 
 import aiohttp.client_exceptions
-from bravado.http_future import FutureAdapter as BaseFutureAdapter
+from bravado.http_future import FutureAdapter as BravadoFutureAdapter
 
 from bravado_asyncio.definitions import AsyncioResponse
+
+
+class BaseFutureAdapter(BravadoFutureAdapter):
+
+    def __init__(self, future: Any) -> None:
+        raise NotImplementedError('Do not instantiate BaseFutureAdapter, use one of its subclasses')
 
 
 class FutureAdapter(BaseFutureAdapter):
@@ -27,6 +34,9 @@ class FutureAdapter(BaseFutureAdapter):
 
         return AsyncioResponse(response=response, remaining_timeout=remaining_timeout)
 
+    def cancel(self) -> None:
+        self.future.cancel()
+
 
 class AsyncioFutureAdapter(BaseFutureAdapter):
     """FutureAdapter that will be used when run_mode is FULL_ASYNCIO. The result method is
@@ -45,3 +55,6 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
         remaining_timeout = timeout - time_elapsed if timeout else None
 
         return AsyncioResponse(response=response, remaining_timeout=remaining_timeout)
+
+    def cancel(self) -> None:
+        self.future.cancel()

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -6,8 +6,10 @@ from typing import Any
 from typing import Callable  # noqa: F401
 from typing import cast
 from typing import Dict
+from typing import MutableMapping
 from typing import Optional
 from typing import Sequence
+from typing import Type
 from typing import Union
 
 import aiohttp
@@ -23,11 +25,11 @@ from yelp_bytes import from_bytes
 
 from bravado_asyncio.definitions import RunMode
 from bravado_asyncio.future_adapter import AsyncioFutureAdapter
+from bravado_asyncio.future_adapter import BaseFutureAdapter
 from bravado_asyncio.future_adapter import FutureAdapter
 from bravado_asyncio.response_adapter import AioHTTPResponseAdapter
 from bravado_asyncio.response_adapter import AsyncioHTTPResponseAdapter
 from bravado_asyncio.thread_loop import get_thread_loop
-
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +85,7 @@ class AsyncioClient(HttpClient):
             self.run_coroutine_func = asyncio.run_coroutine_threadsafe  # type: Callable
             self.response_adapter = AioHTTPResponseAdapter
             self.bravado_future_class = HttpFuture
-            self.future_adapter = FutureAdapter  # type: http_future.FutureAdapter
+            self.future_adapter = FutureAdapter  # type: Type[BaseFutureAdapter]
         elif run_mode == RunMode.FULL_ASYNCIO:
             from aiobravado.http_future import HttpFuture as AsyncioHttpFuture
 
@@ -119,7 +121,7 @@ class AsyncioClient(HttpClient):
 
     def request(
         self,
-        request_params: Dict[str, Any],
+        request_params: MutableMapping[str, Any],
         operation: Optional[Operation] = None,
         request_config: Optional[RequestConfig] = None,
     ) -> HttpFuture:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     install_requires=[
         'aiohttp>=3.3',
-        'bravado>=10.0.0',
+        'bravado>=10.3.0',
         'yelp-bytes',
     ],
     extras_require={

--- a/tests/integration/bravado_integration_test.py
+++ b/tests/integration/bravado_integration_test.py
@@ -14,9 +14,6 @@ class TestServerBravadoAsyncioClient(IntegrationTestsBaseClass):
         aiohttp.ClientConnectionError(),
     }
 
-    def cancel_http_future(self, http_future):
-        http_future.future.future.cancel()
-
     def test_bytes_header(self, swagger_http_server):
         # TODO: integrate this test into bravado integration tests suite
         response = self.http_client.request({


### PR DESCRIPTION
Implement `future.cancel()` from bravado 10.3.0. The new bravado release also uncovered two issues with type hints: one was flat out wrong, the other one was about us passing a parameter to the FutureAdapters `__init__` methods, but the annotated type had no such method.