### PR TITLE
Officially support Python 3.7 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ matrix:
     python: "3.5"
   - env: TOXENV=py36
     python: "3.6"
+  - env: TOXENV=py37
+    python: "3.7"
+    # see https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+    dist: xenial
+    sudo: required
   - env: TOXENV=pre-commit
     python: "3.6"
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     install_requires=[
         'aiohttp>=3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, pre-commit
+envlist = py35, py36, py37, pre-commit
 tox_pip_extensions_ext_venv_update = true
 tox_pip_extensions_ext_pip_custom_platform = true
 


### PR DESCRIPTION
Tests pass locally on an Ubuntu Xenial box, but fail on macOS. I've tried tracking down the issue but was unsuccessful. I'm now assuming it's an issue with Python 3.7's `asyncio` on macOS. Let's see what travis says.