### PR TITLE
Remove workaround for file uploads with filenames of type int

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -149,12 +149,6 @@ class AsyncioClient(HttpClient):
         if isinstance(data, FormData):
             for name, file_tuple in request_params.get('files', {}):
                 stream_obj = file_tuple[1]
-                if not hasattr(stream_obj, 'name') or not isinstance(stream_obj.name, str):
-                    # work around an issue in aiohttp: it's not able to deal with names of type int. We've observed
-                    # this case in the real world and it is a documented possibility:
-                    # https://docs.python.org/3/library/io.html#raw-file-i-o
-                    stream_obj = stream_obj.read()
-
                 data.add_field(name, stream_obj, filename=file_tuple[0])
 
         params = self.prepare_params(request_params.get('params'))

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -179,7 +179,7 @@ def test_file_data_int_filename(asyncio_client, mock_client_session, request_par
     field_data = mock_client_session.return_value.request.call_args[1]['data']._fields[0]
     assert field_data[0]['name'] == 'picture'
     assert field_data[0]['filename'] == 'filename'
-    assert field_data[2] == FileObj.read.return_value
+    assert field_data[2] == FileObj
 
 
 def test_timeouts(asyncio_client, mock_client_session, request_params):


### PR DESCRIPTION
The issue we're working around was fixed in aiohttp 2.3.0 (in aio-libs/aiohttp#2207), and we're already depending on the version being at least 3.3.0. Additionally, the workaround here doesn't seem to work in all cases anymore, as we've discovered internally (CTB-13851).