### PR TITLE
Use pytest < 5.1.0 to fix cover issue about not running all test code on Python 3.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ coverage
 ephemeral_port_reserve
 mock
 mypy
-pytest
+pytest<5.1  # fix Python 3.5 coverage reporting issue
 tox
 tox-pip-extensions
 u-msgpack-python


### PR DESCRIPTION
We make sure all tests are executed by requiring 100% coverage when they're run. This assertion fails on Python 3.5, and it complains about rows not being executed that make no sense (i.e. either it should be more code that's not executed, or that row must have been run).

Travis failure: https://travis-ci.org/sjaensch/bravado-asyncio/jobs/572954056

```
py35 run-test: commands[2] | coverage report --fail-under=100 --include 'tests/*' -m
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
tests/conftest.py                                  13      0   100%
tests/future_adapter_test.py                       44      1    98%   56
tests/http_client_test.py                         107      0   100%
tests/integration/bravado_integration_test.py      15      0   100%
tests/integration/conftest.py                      19      0   100%
tests/integration/integration_test.py             117      1    99%   48
tests/prepare_params_test.py                        6      0   100%
tests/response_adapter_test.py                     61      2    97%   51-52
-----------------------------------------------------------------------------
TOTAL                                             382      4    99%
ERROR: InvocationError for command /home/travis/build/sjaensch/bravado-asyncio/.tox/py35/bin/coverage report --fail-under=100 --include 'tests/*' -m (exited with code 2)
```