### PR TITLE
Fix integration test failure with aiohttp >= 3.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+aiohttp<3.6
 bottle
 bravado-core>=4.11.0
 bravado[integration-tests]>=10.4.1


### PR DESCRIPTION
Integration tests have been failing for some time now, ever since aiohttp 3.6.0 was released. It contains a bug that treats file uploads incorrectly if no content type is specified. Unfortunately the requests library sends no such type, and we do use aiohttp as a HTTP server in our integration tests. I've provided a fix in aio-libs/aiohttp#4090, but it hasn't been merged yet. So let's use a lower version of aiohttp until the issue is fixed.