### PR TITLE
Fix mypy error that popped up with version 0.750, disallow untyped calls

### DIFF
--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -4,6 +4,7 @@ import time
 from typing import Any
 from typing import Optional
 
+import aiohttp
 import aiohttp.client_exceptions
 from bravado.http_future import FutureAdapter as BravadoFutureAdapter
 
@@ -51,7 +52,9 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
 
     async def result(self, timeout: Optional[float] = None) -> AsyncioResponse:
         start = time.monotonic()
-        response = await asyncio.wait_for(self.future, timeout=timeout)
+        response = await asyncio.wait_for(
+            self.future, timeout=timeout
+        )  # type: aiohttp.ClientResponse
         time_elapsed = time.monotonic() - start
         remaining_timeout = timeout - time_elapsed if timeout else None
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,5 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 
 [mypy-bravado_asyncio.*]
-# currently aiohttp has partial type annotations which cause errors if this option is set
-disallow_untyped_calls = False
+disallow_untyped_calls = True
 disallow_untyped_defs = True


### PR DESCRIPTION
This fixes a recent build failure. Additionally I'm setting `disallow_untyped_calls` now that everything we use from bravado / bravado-core is annotated.