### PR TITLE
Bump pre-commit versions, change usage of sha to rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: '^(\.activate\.sh|docs/changelog\.rst)$'
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v1.1.1
+    rev: v2.4.0
     hooks:
     -   id: check-added-large-files
         language_version: python3.6
@@ -30,23 +30,23 @@ repos:
         language_version: python3.6
         files: requirements-dev.txt
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
     -   id: black
         language_version: python3.6
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.7.6
+    rev: 3.7.9
     hooks:
     -   id: flake8
         exclude: ^docs
         language_version: python3.6
 -   repo: https://github.com/asottile/pyupgrade
-    sha: v1.2.0
+    rev: v1.25.1
     hooks:
     -   id: pyupgrade
         language_version: python3.6
 -   repo: https://github.com/asottile/reorder_python_imports
-    sha: v0.3.5
+    rev: v1.8.0
     hooks:
     -   id: reorder-python-imports
         language_version: python3.6

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 import subprocess
 import time


### PR DESCRIPTION
We're still using the outdated `sha` key, which has no effect on recent versions of pre-commit and produces a warning when pre-commit is run. I did `pre-commit autoupdate` to fix those, and bump all versions. I than ran pre-commit on all files.