### PR TITLE
Store client session as loop attribute

### DIFF
--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -34,12 +34,6 @@ from bravado_asyncio.thread_loop import get_thread_loop
 log = logging.getLogger(__name__)
 
 
-#: module variable holding the current :class:`aiohttp.ClientSession`, so that we can share it between
-#: :class:`AsyncioClient` instances. Use :func:`get_client_session` to retrieve it and create one if none
-#: is present.
-client_session = None  # type: Optional[aiohttp.ClientSession]
-
-
 def get_client_session(loop: asyncio.AbstractEventLoop) -> aiohttp.ClientSession:
     """Get a shared ClientSession object that can be reused. If none exists yet it will
     create one using the passed-in loop.
@@ -47,11 +41,12 @@ def get_client_session(loop: asyncio.AbstractEventLoop) -> aiohttp.ClientSession
     :param loop: an active (i.e. not closed) asyncio event loop
     :return: a ClientSession instance that can be used to do HTTP requests
     """
-    global client_session
-    if client_session:
+    try:
+        return loop._bravado_asyncio_client_session
+    except AttributeError:
+        client_session = aiohttp.ClientSession(loop=loop)
+        loop._bravado_asyncio_client_session = client_session
         return client_session
-    client_session = aiohttp.ClientSession(loop=loop)
-    return client_session
 
 
 class AsyncioClient(HttpClient):

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -93,11 +93,6 @@ class AsyncioClient(HttpClient):
                 "Don't know how to handle run mode {}".format(str(run_mode))
             )
 
-        self._client_session = None
-        # don't use the shared client_session if we've been passed an explicit loop argument
-        if loop:
-            self._client_session = aiohttp.ClientSession(loop=loop)
-
         # translate the requests-type SSL options to a ssl.SSLContext object as used by aiohttp.
         # see https://aiohttp.readthedocs.io/en/stable/client_advanced.html#ssl-control-for-tcp-sockets
         if isinstance(ssl_verify, str) or ssl_cert:
@@ -130,10 +125,7 @@ class AsyncioClient(HttpClient):
 
     @property
     def client_session(self) -> aiohttp.ClientSession:
-        if self._client_session is not None:
-            return self._client_session
-        else:
-            return get_client_session(self.loop)
+        return get_client_session(self.loop)
 
     def request(
         self,

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -42,10 +42,10 @@ def get_client_session(loop: asyncio.AbstractEventLoop) -> aiohttp.ClientSession
     :return: a ClientSession instance that can be used to do HTTP requests
     """
     try:
-        return loop._bravado_asyncio_client_session
+        return loop._bravado_asyncio_client_session  # type: ignore
     except AttributeError:
         client_session = aiohttp.ClientSession(loop=loop)
-        loop._bravado_asyncio_client_session = client_session
+        loop._bravado_asyncio_client_session = client_session  # type: ignore
         return client_session
 
 

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -7,8 +7,8 @@ from bravado.http_future import HttpFuture
 
 from bravado_asyncio.future_adapter import FutureAdapter
 from bravado_asyncio.http_client import AsyncioClient
-from bravado_asyncio.http_client import RunMode
 from bravado_asyncio.http_client import get_client_session
+from bravado_asyncio.http_client import RunMode
 from bravado_asyncio.response_adapter import AioHTTPResponseAdapter
 
 
@@ -58,8 +58,8 @@ def test_fail_on_unknown_run_mode():
 
 def test_get_client_session(mock_client_session):
     """Make sure get_client_session caches client sessions per loop."""
-    loop1 = mock.Mock(name='loop1', spec=asyncio.AbstractEventLoop)
-    loop2 = mock.Mock(name='loop2', spec=asyncio.AbstractEventLoop)
+    loop1 = mock.Mock(name="loop1", spec=asyncio.AbstractEventLoop)
+    loop2 = mock.Mock(name="loop2", spec=asyncio.AbstractEventLoop)
 
     mock_client_session.side_effect = [mock.sentinel.session1, mock.sentinel.session2]
 

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -297,9 +297,9 @@ def test_client_from_asyncio(integration_server):
     # this is important since we measure the time this test takes, and the test_timeout() tasks might
     # interfere with it
     loop = thread_loop.get_thread_loop()
-    if http_client.client_session:
-        run_coroutine_threadsafe(http_client.client_session.close(), loop)
-    http_client.client_session = None
+    if hasattr(loop, '_bravado_asyncio_client_session'):
+        run_coroutine_threadsafe(loop._bravado_asyncio_client_session.close(), loop)
+        del loop._bravado_asyncio_client_session
     # not going to properly shut down the running loop, this will be cleaned up on exit
     thread_loop.event_loop = None
 

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -297,7 +297,7 @@ def test_client_from_asyncio(integration_server):
     # this is important since we measure the time this test takes, and the test_timeout() tasks might
     # interfere with it
     loop = thread_loop.get_thread_loop()
-    if hasattr(loop, '_bravado_asyncio_client_session'):
+    if hasattr(loop, "_bravado_asyncio_client_session"):
         run_coroutine_threadsafe(loop._bravado_asyncio_client_session.close(), loop)
         del loop._bravado_asyncio_client_session
     # not going to properly shut down the running loop, this will be cleaned up on exit


### PR DESCRIPTION
The client session is specific to a particular asyncio event loop, so it should not be cached globally.