### PR TITLE
Fix build by making sure we don't use yarl 1.6.0 for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ tox_pip_extensions_ext_pip_custom_platform = true
 [testenv]
 deps =
     -rrequirements-dev.txt
+    yarl!=1.6.0  # that version has a bug where it quotes query parameters, see https://github.com/aio-libs/aiohttp/issues/4972
 setenv =
     PYTHONASYNCIODEBUG=1
 commands =


### PR DESCRIPTION
I don't think there's a released version of aiohttp that sets `yarl!=1.6.0`, although the patch was merged. Either way right now we can't use aiohttp >= 3.6 due to other issues.