### PR TITLE
Remove support for Python 3.5, use Python 3.6 annotation features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 matrix:
   include:
-  - env: TOXENV=py35
-    python: "3.5"
   - env: TOXENV=py36
     python: "3.6"
   - env: TOXENV=py37

--- a/bravado_asyncio/definitions.py
+++ b/bravado_asyncio/definitions.py
@@ -10,7 +10,6 @@ class RunMode(Enum):
     FULL_ASYNCIO = "full_asyncio"
 
 
-AsyncioResponse = NamedTuple(
-    "AsyncioResponse",
-    [("response", aiohttp.ClientResponse), ("remaining_timeout", Optional[float])],
-)
+class AsyncioResponse(NamedTuple):
+    response: aiohttp.ClientResponse
+    remaining_timeout: Optional[float]

--- a/bravado_asyncio/future_adapter.py
+++ b/bravado_asyncio/future_adapter.py
@@ -51,9 +51,9 @@ class AsyncioFutureAdapter(BaseFutureAdapter):
 
     async def result(self, timeout: Optional[float] = None) -> AsyncioResponse:
         start = time.monotonic()
-        response = await asyncio.wait_for(
+        response: aiohttp.ClientResponse = await asyncio.wait_for(
             self.future, timeout=timeout
-        )  # type: aiohttp.ClientResponse
+        )
         time_elapsed = time.monotonic() - start
         remaining_timeout = timeout - time_elapsed if timeout else None
 

--- a/bravado_asyncio/http_client.py
+++ b/bravado_asyncio/http_client.py
@@ -3,7 +3,7 @@ import logging
 import ssl
 from collections.abc import Mapping
 from typing import Any
-from typing import Callable  # noqa: F401
+from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import MutableMapping
@@ -14,7 +14,6 @@ from typing import Union
 
 import aiohttp
 from aiohttp.formdata import FormData
-from bravado import http_future  # noqa
 from bravado.config import RequestConfig
 from bravado.http_client import HttpClient
 from bravado.http_future import HttpFuture
@@ -77,10 +76,10 @@ class AsyncioClient(HttpClient):
         self.run_mode = run_mode
         self._loop = loop
         if self.run_mode == RunMode.THREAD:
-            self.run_coroutine_func = asyncio.run_coroutine_threadsafe  # type: Callable
+            self.run_coroutine_func: Callable = asyncio.run_coroutine_threadsafe
             self.response_adapter = AioHTTPResponseAdapter
             self.bravado_future_class = HttpFuture
-            self.future_adapter = FutureAdapter  # type: Type[BaseFutureAdapter]
+            self.future_adapter: Type[BaseFutureAdapter] = FutureAdapter
         elif run_mode == RunMode.FULL_ASYNCIO:
             from aiobravado.http_future import HttpFuture as AsyncioHttpFuture
 
@@ -96,13 +95,13 @@ class AsyncioClient(HttpClient):
         # translate the requests-type SSL options to a ssl.SSLContext object as used by aiohttp.
         # see https://aiohttp.readthedocs.io/en/stable/client_advanced.html#ssl-control-for-tcp-sockets
         if isinstance(ssl_verify, str) or ssl_cert:
-            self.ssl_verify = None  # type: Optional[bool]
+            self.ssl_verify: Optional[bool] = None
             cafile = None
             if isinstance(ssl_verify, str):
                 cafile = ssl_verify
-            self.ssl_context = ssl.create_default_context(
+            self.ssl_context: Optional[ssl.SSLContext] = ssl.create_default_context(
                 cafile=cafile
-            )  # type: Optional[ssl.SSLContext]
+            )
             if ssl_cert:
                 if isinstance(ssl_cert, str):
                     ssl_cert = [ssl_cert]
@@ -163,8 +162,8 @@ class AsyncioClient(HttpClient):
 
         params = self.prepare_params(request_params.get("params"))
 
-        connect_timeout = request_params.get("connect_timeout")  # type: Optional[float]
-        request_timeout = request_params.get("timeout")  # type: Optional[float]
+        connect_timeout: Optional[float] = request_params.get("connect_timeout")
+        request_timeout: Optional[float] = request_params.get("timeout")
         # mypy thinks the type of total and connect is float, even though it is Optional[float]. Let's ignore the error.
         timeout = (
             aiohttp.ClientTimeout(total=request_timeout, connect=connect_timeout)

--- a/bravado_asyncio/thread_loop.py
+++ b/bravado_asyncio/thread_loop.py
@@ -1,11 +1,11 @@
 """Module for creating a separate thread with an asyncio event loop running inside it."""
 import asyncio
 import threading
-from typing import Optional  # noqa
+from typing import Optional
 
 
 # module variable holding a reference to the event loop
-event_loop = None  # type: Optional[asyncio.AbstractEventLoop]
+event_loop: Optional[asyncio.AbstractEventLoop] = None
 
 
 def run_event_loop(loop: asyncio.AbstractEventLoop) -> None:

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    install_requires=["aiohttp>=3.3", "bravado>=10.3.0", "yelp-bytes"],
+    install_requires=["aiohttp>=3.3", "bravado>=11.0.0", "yelp-bytes"],
     extras_require={
         # as recommended by aiohttp, see http://aiohttp.readthedocs.io/en/stable/#library-installation
         "aiohttp_extras": ["aiodns", "cchardet"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, pre-commit
+envlist = py36, py37, pre-commit
 tox_pip_extensions_ext_venv_update = true
 tox_pip_extensions_ext_pip_custom_platform = true
 


### PR DESCRIPTION
bravado 11 removed support for Python 3.5, let's do the same. We'll release a new major version.