### PR TITLE
Re-enable connection error integration tests on Windows

### DIFF
--- a/bravado_asyncio/response_adapter.py
+++ b/bravado_asyncio/response_adapter.py
@@ -46,7 +46,7 @@ class AioHTTPResponseAdapter(IncomingResponse):
         )  # aiohttp 3.4.0 doesn't annotate this attribute correctly
 
     @property
-    def headers(self) -> CIMultiDictProxy[str]:
+    def headers(self) -> CIMultiDictProxy:
         return self._delegate.headers
 
     def json(self, **_: Any) -> Dict[str, Any]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 aiohttp
 bottle
 bravado-core>=4.11.0
-bravado[integration-tests,fido]>=11.0.1
+bravado[integration-tests,fido]>=11.0.2
 coverage
 ephemeral_port_reserve
 mock<4

--- a/tests/integration/bravado_integration_test.py
+++ b/tests/integration/bravado_integration_test.py
@@ -1,5 +1,3 @@
-import sys
-
 import aiohttp.client_exceptions
 import pytest
 from bravado.testing.integration_test import IntegrationTestsBaseClass
@@ -38,27 +36,3 @@ class TestServerBravadoAsyncioClient(IntegrationTestsBaseClass):
         self, swagger_http_server
     ):  # pragma: no cover
         pass
-
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="Test does not throw correct exception type on Windows",
-    )
-    def test_connection_errors_are_thrown_as_BravadoConnectionError(
-        self, not_answering_http_server
-    ):  # pragma: no cover
-        return super().test_connection_errors_are_thrown_as_BravadoConnectionError(
-            not_answering_http_server
-        )
-
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="Test does not throw correct exception type on Windows",
-    )
-    def test_swagger_client_connection_errors_are_thrown_as_BravadoConnectionError(
-        self, not_answering_http_server, swagger_client, result_getter,
-    ):  # pragma: no cover
-        return super().test_swagger_client_connection_errors_are_thrown_as_BravadoConnectionError(
-            not_answering_http_server=not_answering_http_server,
-            swagger_client=swagger_client,
-            result_getter=result_getter,
-        )


### PR DESCRIPTION
Now that bravado converts connection errors before timeout errors things are much more predictable, and work as expected on Windows too.