### PR TITLE
use https:// instead of git:// in pre-commit urls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # let's ignore symlinks, otherwise certain hooks complain on Windows
 exclude: '^(\.activate\.sh|docs/changelog\.rst)$'
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
     -   id: check-added-large-files


### PR DESCRIPTION
`git://` urls were turned off by github recently in favor of using `https://`